### PR TITLE
fixed dashboard button bug

### DIFF
--- a/app/src/main/java/com/example/nachosbusiness/Dashboard.java
+++ b/app/src/main/java/com/example/nachosbusiness/Dashboard.java
@@ -156,16 +156,47 @@ public class Dashboard extends AppCompatActivity {
         }
 
     /**
-     * Open the specified fragment from the activity
+     * Open the specified fragment from the activity. Disabls themain screen buttons as the buttons were
+     * clickable when a fragment was opened even though they were visible.
      * @param fragment fragment to open
      * Reference: https://developer.android.com/guide/fragments/transactions
      */
     public void loadFragment(Fragment fragment) {
+        disableDashboardButtons();
         FragmentManager fragmentManager = getSupportFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
         fragmentTransaction.replace(R.id.dashboard_fragment_container, fragment);
         fragmentTransaction.addToBackStack(null);
-
         fragmentTransaction.commit();
+
+        fragmentManager.addOnBackStackChangedListener(() -> {
+            if (fragmentManager.getBackStackEntryCount() == 0) {
+                enableDashboardButtons();
+            }
+        });
+    }
+
+    /**
+     * Disable the main dashboard buttons. Will have to add the items in the user event list here
+     */
+    private void disableDashboardButtons() {
+        findViewById(R.id.button_your_events).setEnabled(false);
+        findViewById(R.id.button_browse).setEnabled(false);
+        findViewById(R.id.button_facility).setEnabled(false);
+        findViewById(R.id.button_profile).setEnabled(false);
+        findViewById(R.id.button_event_updates).setEnabled(false);
+        findViewById(R.id.button_join_events).setEnabled(false);
+    }
+
+    /**
+     * enables the main dashboard buttons. Will have to add the items in the user event list here
+     */
+    private void enableDashboardButtons() {
+        findViewById(R.id.button_your_events).setEnabled(true);
+        findViewById(R.id.button_browse).setEnabled(true);
+        findViewById(R.id.button_facility).setEnabled(true);
+        findViewById(R.id.button_profile).setEnabled(true);
+        findViewById(R.id.button_event_updates).setEnabled(true);
+        findViewById(R.id.button_join_events).setEnabled(true);
     }
 }


### PR DESCRIPTION
fixed a bug where the dashboard buttons were still clickable when loading in a new fragment. Now can't click open camera from other fragments. 

Might be a better way to do this but deadlines...